### PR TITLE
feat: one-command setup + structured first-session + RAI community governance

### DIFF
--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -80,60 +80,109 @@ run_update_check() {
 # ---------------------------------------------------------------------------
 # Dependency skill checker
 # Elektra works best with companion skills. Check on first session.
+# Emits structured, agent-actionable output with version envelope.
 # ---------------------------------------------------------------------------
 check_dependency_skills() {
-  local SKILLS_DIR="$HOME/.claude/skills"
+  local LOCAL_SKILLS=".claude/skills"
+  local LOCAL_AGENTS=".agents/skills"
+  local GLOBAL_SKILLS="$HOME/.claude/skills"
   local PLUGINS_CACHE="$HOME/.claude/plugins/cache"
-  local MISSING=()
+
+  local MISSING_REQ_NAMES=()
+  local MISSING_REC_NAMES=()
+  local MISSING_SLUGS=()
   local INSTALLED=()
 
-  # Dependency table: name|install_cmd|description|search_patterns (colon-separated glob paths)
-  local DEPS=(
-    "gstack|npx skills add garrytan/gstack -g -y|Governor Stack -- QA, review, browser testing, ship workflows|$SKILLS_DIR/gstack:$SKILLS_DIR/*/gstack"
-    "superpowers|npx skills add obra/superpowers -g -y|Planning, code review, parallel agent dispatch|$SKILLS_DIR/superpowers:$PLUGINS_CACHE/superpowers-dev/superpowers"
-    "claude-mem|npx skills add thedotmack/claude-mem -g -y|Persistent memory search across sessions (recommended)|$SKILLS_DIR/claude-mem:$PLUGINS_CACHE/thedotmack/claude-mem"
-    "ui-ux-pro-max|npx skills add ui-ux-pro-max -g -y|50+ styles, 99 UX guidelines, design review for P3.5/P4.5 (recommended)|$SKILLS_DIR/ui-ux-pro-max:$PLUGINS_CACHE/*/ui-ux-pro-max*"
-    "everything-claude-code|npx skills add affaan-m/everything-claude-code -g -y|100+ agent skills -- TDD, code review, build resolution (optional)|$SKILLS_DIR/everything-claude-code:$PLUGINS_CACHE/*/everything-claude-code"
-  )
-
-  for dep in "${DEPS[@]}"; do
-    IFS='|' read -r name cmd desc paths <<< "$dep"
-    local found=false
-    IFS=':' read -ra SEARCH_PATHS <<< "$paths"
-    for pattern in "${SEARCH_PATHS[@]}"; do
+  # Check if a skill is installed at any known path (local + global)
+  is_skill_installed() {
+    local paths="$1"
+    IFS=':' read -ra search <<< "$paths"
+    for pattern in "${search[@]}"; do
       # shellcheck disable=SC2086
       if ls $pattern 2>/dev/null | head -1 >/dev/null 2>&1; then
-        found=true
-        break
+        return 0
       fi
     done
-    if [[ "$found" == "true" ]]; then
+    return 1
+  }
+
+  # Required companion skills: name|install_slug|search_paths
+  local REQUIRED=(
+    "gstack|garrytan/gstack|$GLOBAL_SKILLS/gstack:$GLOBAL_SKILLS/*/gstack:$LOCAL_SKILLS/gstack:$LOCAL_AGENTS/gstack"
+    "superpowers|obra/superpowers|$GLOBAL_SKILLS/superpowers:$PLUGINS_CACHE/superpowers-dev/superpowers:$LOCAL_SKILLS/superpowers:$LOCAL_AGENTS/superpowers"
+  )
+
+  # Recommended companion skills
+  local RECOMMENDED=(
+    "claude-mem|thedotmack/claude-mem|$GLOBAL_SKILLS/claude-mem:$PLUGINS_CACHE/thedotmack/claude-mem:$LOCAL_SKILLS/claude-mem:$LOCAL_AGENTS/claude-mem"
+    "ui-ux-pro-max|ui-ux-pro-max|$GLOBAL_SKILLS/ui-ux-pro-max:$PLUGINS_CACHE/*/ui-ux-pro-max*:$LOCAL_SKILLS/ui-ux-pro-max:$LOCAL_AGENTS/ui-ux-pro-max"
+    "everything-claude-code|affaan-m/everything-claude-code|$GLOBAL_SKILLS/everything-claude-code:$PLUGINS_CACHE/*/everything-claude-code:$LOCAL_SKILLS/everything-claude-code:$LOCAL_AGENTS/everything-claude-code"
+  )
+
+  for dep in "${REQUIRED[@]}"; do
+    IFS='|' read -r name slug paths <<< "$dep"
+    if is_skill_installed "$paths"; then
       INSTALLED+=("$name")
     else
-      MISSING+=("$name|$cmd|$desc")
+      MISSING_REQ_NAMES+=("$name")
+      MISSING_SLUGS+=("$slug")
     fi
   done
 
-  # Report
-  if [[ ${#MISSING[@]} -gt 0 ]]; then
-    echo ""
-    echo "[ELEKTRA] Dependency Check:"
-    echo ""
-    for skill in "${INSTALLED[@]}"; do
-      echo "  [x] $skill"
-    done
-    for entry in "${MISSING[@]}"; do
-      IFS='|' read -r name cmd desc <<< "$entry"
-      echo "  [ ] $name -- $desc"
-      echo "      Install: $cmd"
-    done
-    echo ""
-    echo "Install all missing with:"
-    echo "  npx skills add garrytan/gstack obra/superpowers thedotmack/claude-mem ui-ux-pro-max -g -y"
-    echo ""
-  else
-    echo "[ELEKTRA] All dependency skills installed: ${INSTALLED[*]}"
+  for dep in "${RECOMMENDED[@]}"; do
+    IFS='|' read -r name slug paths <<< "$dep"
+    if is_skill_installed "$paths"; then
+      INSTALLED+=("$name")
+    else
+      MISSING_REC_NAMES+=("$name")
+      MISSING_SLUGS+=("$slug")
+    fi
+  done
+
+  # Resolve elektra-config path for agent instructions
+  local config_cmd="elektra-config"
+  local elektra_dir
+  elektra_dir="$(detect_elektra_dir 2>/dev/null)" || true
+  if [[ -n "${elektra_dir:-}" ]] && [[ -x "$elektra_dir/bin/elektra-config" ]]; then
+    config_cmd="$elektra_dir/bin/elektra-config"
   fi
+
+  # All installed — emit auto-update action only
+  if [[ ${#MISSING_REQ_NAMES[@]} -eq 0 ]] && [[ ${#MISSING_REC_NAMES[@]} -eq 0 ]]; then
+    echo "[ELEKTRA] All dependency skills installed: ${INSTALLED[*]}"
+    echo ""
+    echo "[ELEKTRA_FIRST_SESSION_BEGIN v1]"
+    echo "ACTIONS_COUNT: 1"
+    echo "ACTION_1_TYPE: update_notifications"
+    echo "ACTION_1_PROMPT: Enable update notifications? Elektra will tell you when new versions are available. [Y/n]"
+    echo "ACTION_1_YES_CMD: $config_cmd set update_check true"
+    echo "ACTION_1_NO_CMD: $config_cmd set update_check false"
+    echo "[ELEKTRA_FIRST_SESSION_END]"
+    return
+  fi
+
+  # Build dynamic INSTALL_CMD from missing skills only
+  local install_cmd
+  if command -v npx >/dev/null 2>&1; then
+    install_cmd="npx skills add ${MISSING_SLUGS[*]} -g -y"
+  else
+    install_cmd="(npx not found -- install Node.js first, then: npx skills add ${MISSING_SLUGS[*]} -g -y)"
+  fi
+
+  # Emit structured first-session block (combined deps + update config)
+  echo ""
+  echo "[ELEKTRA_FIRST_SESSION_BEGIN v1]"
+  echo "ACTIONS_COUNT: 2"
+  echo "ACTION_1_TYPE: companion_skills"
+  [[ ${#MISSING_REQ_NAMES[@]} -gt 0 ]] && echo "ACTION_1_MISSING_REQUIRED: ${MISSING_REQ_NAMES[*]}"
+  [[ ${#MISSING_REC_NAMES[@]} -gt 0 ]] && echo "ACTION_1_MISSING_RECOMMENDED: ${MISSING_REC_NAMES[*]}"
+  echo "ACTION_1_INSTALL_CMD: $install_cmd"
+  echo "ACTION_2_TYPE: update_notifications"
+  echo "ACTION_2_PROMPT: Enable update notifications? Elektra will tell you when new versions are available. [Y/n]"
+  echo "ACTION_2_YES_CMD: $config_cmd set update_check true"
+  echo "ACTION_2_NO_CMD: $config_cmd set update_check false"
+  echo "SEQUENCE: ACTION_1 first, then ACTION_2"
+  echo "[ELEKTRA_FIRST_SESSION_END]"
 }
 
 # ---------------------------------------------------------------------------

--- a/.github/ISSUE_TEMPLATE/responsible-ai.yml
+++ b/.github/ISSUE_TEMPLATE/responsible-ai.yml
@@ -1,0 +1,83 @@
+name: Responsible AI Improvement
+description: Propose an improvement to Elektra's RAI governance (kill switches, checks, pillars, detection)
+title: "RAI: "
+labels: ["responsible-ai", "community", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Responsible AI Improvement Proposal
+
+        Elektra's RAI governance is community-driven. Every improvement should be born from a real incident, a real gap, or a real-world scenario — not theoretical.
+
+  - type: dropdown
+    id: pillar
+    attributes:
+      label: Which RAI pillar does this affect?
+      options:
+        - Tenant / Data Isolation
+        - PII Protection
+        - Citation Integrity
+        - Confidence Scoring
+        - Hallucination Prevention
+        - Bias Mitigation
+        - Content Provenance
+        - New pillar (describe below)
+        - Cross-cutting (multiple pillars)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Which component should change?
+      options:
+        - rai-check.sh (hook detection)
+        - responsible-ai/SKILL.md (skill definition)
+        - responsible-ai/references/rai-checklist.md (checklist)
+        - CLAUDE.md (kill switches / coding standards)
+        - cycle-guard.sh (workflow enforcement)
+        - quality-gate.sh (post-edit checks)
+        - New component needed
+      multiple: true
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened? (The real-world scenario)
+      description: Describe the incident, gap, or near-miss that motivates this change. "Theoretical" proposals without real scenarios will be deprioritized.
+      placeholder: "During a production session, an agent silently swallowed an auth check failure and..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What should change?
+      description: Be specific. Include file paths, detection patterns, or rule text.
+      placeholder: "Add detection pattern for bare `except` blocks in rai-check.sh..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: detection
+    attributes:
+      label: How would this be detected/enforced?
+      description: File path patterns, code patterns, hook logic, or checklist items.
+      placeholder: "Pattern match: `except.*return \\[\\]` in Python files"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Contribution checklist
+      options:
+        - label: This is based on a real incident or gap (not theoretical)
+          required: true
+        - label: This is framework-agnostic (not tied to a specific project)
+          required: true
+        - label: This doesn't break existing skill activation patterns
+          required: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,17 +30,17 @@ I bridge strategy and execution. I do not just reply -- I think, plan, execute, 
 
 ## Companion Skills
 
-Elektra's Standing Orders are self-contained. These companion skills extend capabilities:
+Elektra's Standing Orders are self-contained. These companion skills extend capabilities. Installed via agent prompt on first session -- no separate command needed.
 
-| Skill | Required? | Install | What It Adds |
-|-------|-----------|---------|-------------|
-| **[gstack](https://skills.sh/garrytan/gstack)** | Required | `npx skills add garrytan/gstack -g -y` | QA, review, browser testing, ship workflows |
-| **[superpowers](https://skills.sh/obra)** | Required | `npx skills add obra/superpowers -g -y` | Planning, code review, parallel agent dispatch |
-| **[claude-mem](https://skills.sh/thedotmack/claude-mem)** | Recommended | `npx skills add thedotmack/claude-mem -g -y` | Persistent memory search across sessions |
-| **[ui-ux-pro-max](https://uupm.cc)** | Recommended | `npx skills add ui-ux-pro-max -g -y` | 50+ styles, 161 color palettes, 99 UX guidelines, design review |
-| **[everything-claude-code](https://github.com/affaan-m/everything-claude-code)** | Optional | `npx skills add affaan-m/everything-claude-code -g -y` | 100+ meta-skills (TDD, build resolution, code review agents) |
+| Skill | Required? | What It Adds |
+|-------|-----------|-------------|
+| **[gstack](https://skills.sh/garrytan/gstack)** | Required | QA, review, browser testing, ship workflows |
+| **[superpowers](https://skills.sh/obra)** | Required | Planning, code review, parallel agent dispatch |
+| **[claude-mem](https://skills.sh/thedotmack/claude-mem)** | Recommended | Persistent memory search across sessions |
+| **[ui-ux-pro-max](https://uupm.cc)** | Recommended | 50+ styles, 161 color palettes, 99 UX guidelines, design review |
+| **[everything-claude-code](https://github.com/affaan-m/everything-claude-code)** | Optional | 100+ meta-skills (TDD, build resolution, code review agents) |
 
-`session-init.sh` checks for these on first session and reports missing dependencies.
+"Required" = strong agent prompt on first session. QA, plan review, and code review depend on gstack and superpowers. "Recommended" = softer prompt, not blocking. `session-init.sh` detects missing deps and emits structured install instructions the agent acts on.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,35 @@ Every change must:
 - **Follow the SKILL.md spec.** Valid frontmatter, clear trigger descriptions, progressive disclosure via `references/`.
 - **Pass validation.** `npx skills validate` must pass on all modified skills.
 
+## Responsible AI — Community-Driven
+
+Elektra's RAI governance is open for community hardening. The 7-pillar framework, kill switches, hook detection, and checklists all accept contributions.
+
+### How to contribute RAI improvements
+
+1. **Use the issue template.** Click "New Issue" > "Responsible AI Improvement" on [GitHub](https://github.com/architect-4-citadell/elektra-skills/issues/new/choose). The template asks for the pillar, the component, the real-world scenario, and the proposed change.
+
+2. **Real incidents only.** Every RAI rule in Elektra was born from a production bug, a near-miss, or a compliance gap. Theoretical proposals without real scenarios will be deprioritized.
+
+3. **Framework-agnostic.** RAI rules must work across Python, TypeScript, Go, Rust — any stack. Include language-specific detection as optional appendices, not core rules.
+
+### What we're looking for
+
+| Area | Examples |
+|------|---------|
+| **Kill switch triggers** | New halt conditions for agent execution |
+| **Hook detection patterns** | File path or code patterns for `rai-check.sh` |
+| **Checklist items** | Additions to `responsible-ai/references/rai-checklist.md` |
+| **Layer mappings** | Which RAI pillars apply to which architectural layers |
+| **Subagent review patterns** | Systematic AI-generated code mistakes |
+| **Fallback logging rules** | Silent failure detection and logging mandates |
+
+### Active RAI issues
+
+Browse issues labeled [`responsible-ai`](https://github.com/architect-4-citadell/elektra-skills/labels/responsible-ai) for open work. Issues marked [`community`](https://github.com/architect-4-citadell/elektra-skills/labels/community) are specifically designed for external contributors.
+
+---
+
 ## What we won't merge
 
 - Skills that are project-specific (not generalizable)

--- a/README.md
+++ b/README.md
@@ -61,31 +61,13 @@ your-project/
 
 ## Quick Start
 
-### 1. Install Elektra
-
 ```bash
-npx skills add architect-4-citadell/elektra-skills
+npx skills add architect-4-citadell/elektra-skills -y
 ```
 
-### 2. Install companion skills
+Open your agent. On first session, Elektra onboards herself and you, offers to install companion skills, and configures update notifications. One command. That's it.
 
-```bash
-npx skills add garrytan/gstack obra/superpowers thedotmack/claude-mem ui-ux-pro-max -g -y
-```
-
-| Skill | Required? | What It Adds |
-|-------|-----------|-------------|
-| **[gstack](https://skills.sh/garrytan/gstack)** | Required | QA, plan review, code review, browser testing, ship workflows |
-| **[superpowers](https://skills.sh/obra)** | Required | Planning, code review, parallel agent dispatch |
-| **[claude-mem](https://skills.sh/thedotmack/claude-mem)** | Recommended | Persistent memory search across sessions |
-| **[ui-ux-pro-max](https://uupm.cc)** | Recommended | 50+ styles, 161 palettes, 99 UX guidelines, design review |
-| **[everything-claude-code](https://github.com/affaan-m/everything-claude-code)** | Optional | 100+ meta-skills (TDD, build resolution, code review agents) |
-
-### 3. Start a session
-
-Open your agent. Elektra detects the first session, onboards herself and you, then asks what you're working on.
-
-### 4. (Optional) Pair with Conductor
+### (Optional) Pair with Conductor
 
 For multi-agent orchestration, parallel execution, and cross-workspace coordination:
 
@@ -264,15 +246,26 @@ Pair with **[claude-mem](https://skills.sh/thedotmack/claude-mem)** for search a
 
 ---
 
+## Companion Skills
+
+Elektra offers to install these on first session. No separate command needed.
+
+| Skill | Required? | What It Adds |
+|-------|-----------|-------------|
+| **[gstack](https://skills.sh/garrytan/gstack)** | Required | QA, plan review, code review, browser testing, ship workflows |
+| **[superpowers](https://skills.sh/obra)** | Required | Planning, code review, parallel agent dispatch |
+| **[claude-mem](https://skills.sh/thedotmack/claude-mem)** | Recommended | Persistent memory search across sessions |
+| **[ui-ux-pro-max](https://uupm.cc)** | Recommended | 50+ styles, 161 palettes, 99 UX guidelines, design review |
+| **[everything-claude-code](https://github.com/affaan-m/everything-claude-code)** | Optional | 100+ meta-skills (TDD, build resolution, code review agents) |
+
+"Required" means Elektra strongly recommends them -- QA, plan review, and code review features depend on gstack and superpowers. "Recommended" skills improve the experience but aren't blocking.
+
+---
+
 ## Built On
 
 | Name | Role |
 |------|------|
-| **[gstack](https://skills.sh/garrytan/gstack)** | Governor Stack -- structured AI agent workflow governance |
-| **[superpowers](https://skills.sh/obra)** | AI agent composition, planning, and code review |
-| **[claude-mem](https://skills.sh/thedotmack/claude-mem)** | Persistent memory search across sessions |
-| **[ui-ux-pro-max](https://uupm.cc)** | 50+ styles, 161 color palettes, 99 UX guidelines, design review |
-| **[everything-claude-code](https://github.com/affaan-m/everything-claude-code)** | 100+ Claude Code meta-skills, agents, and hooks |
 | **[autoresearch (Karpathy)](https://github.com/karpathy/autoresearch)** | Autonomous iteration loop -- the original inspiration |
 | **[skills.sh](https://skills.sh)** | Open agent skills ecosystem -- discovery + distribution |
 | **[Agent Skills Specification](https://agentskills.io)** | The format standard these skills follow |
@@ -323,6 +316,14 @@ Building a commercial product with these skills? See [COMMERCIAL_LICENSE.md](./C
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md). Every contribution must solve a real problem -- not a theoretical one.
+
+### Responsible AI -- Community-Driven
+
+Elektra's RAI governance accepts community hardening. Kill switches, hook detection, the 7-pillar checklist, and layer mappings are all open for improvement.
+
+Browse open issues: [`responsible-ai`](https://github.com/architect-4-citadell/elektra-skills/labels/responsible-ai) | Submit: [New RAI Improvement](https://github.com/architect-4-citadell/elektra-skills/issues/new?template=responsible-ai.yml)
+
+Every rule was born from a real incident. Yours should be too.
 
 ---
 

--- a/setup
+++ b/setup
@@ -20,4 +20,10 @@ chmod +x "$ELEKTRA_DIR/setup" 2>/dev/null || true
 # Create state directory
 mkdir -p "$HOME/.elektra"
 
+# Set sensible default config (update notifications ON)
+# Guarded: skip if config already exists, don't fail setup if write errors
+if [ ! -f "$HOME/.elektra/config.yaml" ]; then
+  "$ELEKTRA_DIR/bin/elektra-config" set update_check true 2>/dev/null || true
+fi
+
 echo "Elektra Skills $(cat "$ELEKTRA_DIR/VERSION" 2>/dev/null || echo "unknown") — setup complete."


### PR DESCRIPTION
## Summary

- **One-command install.** Quick Start reduced from 2 steps to `npx skills add architect-4-citadell/elektra-skills -y`. Companion skills offered via agent prompt on first session — no separate command.
- **Structured first-session protocol.** `session-init.sh` emits `[ELEKTRA_FIRST_SESSION_BEGIN v1]` envelope with dynamic `INSTALL_CMD` (only missing skills), required/recommended separation, `npx` availability check, local+global path detection, and combined companion skills + update notifications action block.
- **RAI community governance.** 6 issues filed (#5-#10), `responsible-ai` label + issue template, CONTRIBUTING.md section for community-driven RAI hardening. Derived from production Zypher Elektra v4.0.

## Changes

| File | What |
|------|------|
| `session-init.sh` | Rewritten `check_dependency_skills()` with structured output |
| `setup` | Error-guarded default config write (`update_check: true`) |
| `README.md` | One-command Quick Start, companion skills reference section |
| `CLAUDE.md` | Companion skills via agent prompt, not manual install |
| `CONTRIBUTING.md` | RAI community contribution guide |
| `.github/ISSUE_TEMPLATE/responsible-ai.yml` | Structured RAI submission form |

## RAI Roadmap (Issues #5-#10)

| # | P | Title |
|---|---|-------|
| #5 | P1 | Expand kill switch to 4 specific triggers |
| #6 | P1 | Mandate fallback logging format |
| #7 | P2 | E2E smoke test gate per session |
| #8 | P2 | Subagent/AI-generated code review checklist |
| #9 | P3 | Doc-sync drift audit protocol |
| #10 | P3 | Layer-mapped RAI governance |

## Test plan

- [x] `bash -n` syntax check on session-init.sh and setup
- [x] Smoke test: session-init.sh produces clean structured output
- [x] Setup idempotency: second run doesn't overwrite existing config
- [x] All companion skills detected (local + global paths)
- [ ] Fresh project install: `npx skills add architect-4-citadell/elektra-skills -y` → first session triggers onboarding + companion prompt
- [ ] Missing skills scenario: remove one skill, verify dynamic INSTALL_CMD
- [ ] No npx scenario: verify fallback message

🤖 Generated with [Claude Code](https://claude.com/claude-code)