### PR TITLE
fix: timestamp archives + compact partial-onboarding output

### DIFF
--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -200,11 +200,8 @@ if [[ ! -f "MEMORY.md" ]]; then
 
 elif ! grep -q "user_profile" "MEMORY.md" 2>/dev/null; then
   # Memory exists but no user profile -- partial onboarding
-  cat << 'CONTEXT'
-[ELEKTRA] Returning project, new user. MEMORY.md found but no user profile.
-Run User Onboarding (Phase B of First Session Protocol).
-Ask all questions in TWO batched prompts, then save to user_profile.md.
-CONTEXT
+  echo "[ELEKTRA] Returning project, new user. Run Phase B (user onboarding per CLAUDE.md)."
+  echo "Batch all questions in TWO prompts."
 
 else
   # Returning session -- compact status

--- a/init-elektra/SKILL.md
+++ b/init-elektra/SKILL.md
@@ -45,13 +45,13 @@ Run the full First Session Protocol from CLAUDE.md:
 
 1. Inform the user that existing onboarding data was found.
 2. Ask: **"Re-run full onboarding (project + user), or just update your user profile?"**
-   - **Full reset**: archive existing `project_discovery.md` and `user_profile.md` (rename with `_prev` suffix), then run Phases A-E.
-   - **Profile only**: archive `user_profile.md`, re-run Phase B only, update MEMORY.md index.
+   - **Full reset**: archive existing `project_discovery.md` and `user_profile.md` (rename with `_prev_YYYYMMDD_HHMMSS` timestamp suffix), then run Phases A-E.
+   - **Profile only**: archive `user_profile.md` (timestamp suffix), re-run Phase B only, update MEMORY.md index.
 3. After re-onboarding completes, confirm the new register (S1-S4) and announce readiness.
 
 ## Rules
 
-- Never delete memory files outright -- archive with `_prev` suffix so nothing is lost.
+- Never delete memory files outright -- archive with `_prev_YYYYMMDD_HHMMSS` timestamp suffix so nothing is lost.
 - Always run Phase A before Phase B in full reset -- project context informs which Phase B questions to skip.
 - Batch all onboarding questions in TWO prompts, never one-by-one.
 - After completing onboarding, announce: `[ELEKTRA] Onboarding complete. Register: {band}. Ready.`


### PR DESCRIPTION
## Summary

Follow-up to #12. Addresses two findings from the adversarial review:

- **Timestamp archives on re-onboarding:** `_prev` suffix now uses `_prev_YYYYMMDD_HHMMSS` to avoid overwriting prior archives on repeated `/init-elektra` runs
- **Compact partial-onboarding output:** The middle branch (MEMORY.md exists, no user profile) was still using verbose heredoc style while the other two branches were compacted

## Test plan
- [x] session-init.sh runs clean across all 3 detection paths
- [x] init-elektra/SKILL.md archive instructions use timestamp suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)